### PR TITLE
tspreed: move to tspreed-git

### DIFF
--- a/neko
+++ b/neko
@@ -167,7 +167,7 @@ _EOF
 			;;
 		"emerge")
 			cat << _EOF
-[1museage[0m
+[1musage[0m
 ${0} em <target>
 OR
 ${0} emerge <target>
@@ -538,6 +538,8 @@ neko_extract()
 	if [ -n "${distfiles}" ] || [ -n "${giturl}" ]
 	then
 		cd "${wrksrc}" || exit
+		[ -n "${commit}" ] && git checkout "${commit}"
+		unset commit
 	fi
 }
 

--- a/srcpkgs/tspreed-git/template
+++ b/srcpkgs/tspreed-git/template
@@ -1,8 +1,8 @@
-pkgname="tspreed"
+pkgname="tspreed-git"
 short_desc="Terminal RSVP speed reader with Spritz-like functionality"
-version="2.0.1"
+commit="d059dde0b3a05401e78735a3aacaaa27e14c49a9"
 revision="1"
-distfiles="https://github.com/n-ivkovic/tspreed/archive/v${version}.tar.gz"
+giturl="https://github.com/n-ivkovic/tspreed.git"
 build_style="makefile"
 license="GPL-3.0-or-later"
 


### PR DESCRIPTION
After the mentioned commit - upstream gives no option for userspace that has strictly POSIX standard sleep (1p). The suckless userspace is planned to be used and does *NOT* support non-int numbers to `sleep`. This might be a common thing maintainers might want to do - package a specific commit. So, there's now a "commit" variable to specify which commit to checkout for git builds.